### PR TITLE
Enhance Python injection syntax via Issue #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.3.2
+
+- Fix syntax highlighting breaking when CSS strings are commented out
+
 ## 1.3.1
 
 - Add support for `panel` border type
@@ -39,3 +43,4 @@
 ## 0.1.0
 
 - Initial release
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "textual-syntax-highlighter",
   "displayName": "Textual Syntax Highlighter",
   "description": "Enables syntax highlighting for Textual CSS",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "icon": "icon.png",
   "repository": "https://github.com/Textualize/tcss-vscode-extension",
   "publisher": "Textualize",

--- a/syntaxes/python.injection.json
+++ b/syntaxes/python.injection.json
@@ -3,9 +3,10 @@
     "injectionSelector": "L:source.python",
     "patterns": [
         {
-            "begin": "(?:(?:DEFAULT_)?CSS = (\"\"\"))",
+            "begin": "^(?!\\s*[#/])\\s*((?:DEFAULT_)?CSS\\s*=\\s*(\"\"\"))",
             "beginCaptures": {
-                "1": { "name": "string.quoted.multi.python punctuation.definition.string.begin.python" }
+                "1": { "name": "meta.css.declaration.python" },
+                "2": { "name": "string.quoted.multi.python punctuation.definition.string.begin.python" }
             },
             "end": "(\"\"\")",
             "endCaptures": {
@@ -16,9 +17,10 @@
             ]
         },
         {
-            "begin": "(?:(?:DEFAULT_)?CSS = ('''))",
+            "begin": "^(?!\\s*[#/])\\s*((?:DEFAULT_)?CSS\\s*=\\s*('''))",
             "beginCaptures": {
-                "1": { "name": "string.quoted.multi.python punctuation.definition.string.begin.python" }
+                "1": { "name": "meta.css.declaration.python" },
+                "2": { "name": "string.quoted.multi.python punctuation.definition.string.begin.python" }
             },
             "end": "(''')",
             "endCaptures": {
@@ -29,9 +31,10 @@
             ]
         },
         {
-            "begin": "(?:(?:DEFAULT_)?CSS = (\"))",
+            "begin": "^(?!\\s*[#/])\\s*((?:DEFAULT_)?CSS\\s*=\\s*(\"))",
             "beginCaptures": {
-                "1": { "name": "string.quoted.single.python punctuation.definition.string.begin.python" }
+                "1": { "name": "meta.css.declaration.python" },
+                "2": { "name": "string.quoted.single.python punctuation.definition.string.begin.python" }
             },
             "end": "(\")",
             "endCaptures": {
@@ -42,9 +45,10 @@
             ]
         },
         {
-            "begin": "(?:(?:DEFAULT_)?CSS = ('))",
+            "begin": "^(?!\\s*[#/])\\s*((?:DEFAULT_)?CSS\\s*=\\s*('))",
             "beginCaptures": {
-                "1": { "name": "string.quoted.single.python punctuation.definition.string.begin.python" }
+                "1": { "name": "meta.css.declaration.python" },
+                "2": { "name": "string.quoted.single.python punctuation.definition.string.begin.python" }
             },
             "end": "(')",
             "endCaptures": {


### PR DESCRIPTION
This change improves the TextMate grammar patterns in `python.injection.json` and adds some explicit checks for comment characters at the start of lines, which should fix #6. 

There's also some better handling of white-space around CSS string declarations

## E.g.
<img width="665" alt="Screenshot 2025-04-23 at 1 25 54 PM" src="https://github.com/user-attachments/assets/458ab9dc-153e-4148-8a9c-85103cc4fd6d" />
